### PR TITLE
install pyADCS and HashiCorpVault by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+czertainly-appliance-tools (2.14.1~rc1) stable; urgency=medium
+  * install pyADCS connector by default
+  * install HashiCorp Vault connector by default
+ -- Jan Tomášek <jan.tomasek@3key.company>  Mon, 10 Feb 2024 19:00:00 +0100
+
 czertainly-appliance-tools (2.13.2-1) stable; urgency=medium
   * fix docker.yaml formating
  -- Jan Tomášek <jan.tomasek@3key.company>  Thu, 14 Nov 2024 19:00:00 +0100

--- a/etc/czertainly-ansible/vars/czertainly.yml
+++ b/etc/czertainly-ansible/vars/czertainly.yml
@@ -1,10 +1,10 @@
 ---
 czertainly:
-  version: 2.13.1
+  version: 2.14.0
   commonCredentialProvider: true
   ejbcaNgConnector: true
-  pymsAdcsConnector: false
-  hashicorpVaultConnector: false
+  pymsAdcsConnector: true
+  hashicorpVaultConnector: true
   x509ComplianceProvider: true
   cryptosenseDiscoveryProvider: false
   ctLogsDiscoveryProvider: true


### PR DESCRIPTION
pyADCS and HashiCorpVault are free components

closes #102
closes #96 