### PR TITLE
assert hostnames are in lowercase

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
-czertainly-appliance-tools (2.14.1~rc1) stable; urgency=medium
+czertainly-appliance-tools (2.14.1~rc2) stable; urgency=medium
   * install pyADCS connector by default
   * install HashiCorp Vault connector by default
+  * assert hostnames lowercase
  -- Jan Tomášek <jan.tomasek@3key.company>  Mon, 10 Feb 2024 19:00:00 +0100
 
 czertainly-appliance-tools (2.13.2-1) stable; urgency=medium

--- a/etc/czertainly-ansible/playbooks/czertainly.yml
+++ b/etc/czertainly-ansible/playbooks/czertainly.yml
@@ -12,6 +12,10 @@
     - name: CZERTAINLY versions
       ansible.builtin.debug:
         msg: "{{ versions.stdout }}"
+    - name: Assert lowercase hostname
+      ansible.builtin.assert:
+        that: ansible_fqdn is match("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+        fail_msg: "System hostname, has to be all lowercase, {{ ansible_fqdn }} doesn't match that rule. This is enforced by Kubernetes."
     - name: Check if keycloak file exists
       ansible.builtin.stat:
         path: "/etc/czertainly-ansible/vars/keycloak.yml"

--- a/usr/bin/czertainly-tui
+++ b/usr/bin/czertainly-tui
@@ -1201,7 +1201,7 @@ changeHostname() {
     hostname=`hostname -f`
 
     dialog --backtitle "$backTitleCentered" --title " System hostname " \
-       --form "\nWARNING: Changing the hostname will reboot the system.\n\nProvide fully qualifiled hostname" 12 $eCOLS 1 \
+       --form "\nWARNING: Changing the hostname will reboot the system.\n\nProvide fully qualified hostname. It has to be all lowercase and starting with a letter." 12 $eCOLS 1 \
        ""  1 1 "$hostname" 1 2 $maxInputLen $maxLen \
        2>$tmpF
     # get dialog's exit status
@@ -1213,7 +1213,7 @@ changeHostname() {
         return 1
     fi
 
-    cat $tmpF | sed "s/^ //gm" | sed "s/ $//gm" | {
+    cat $tmpF | sed "s/^ //gm" | sed "s/ $//gm" | tr '[A-Z]' '[a-z'] | {
         read -r _hostname
 
         lines=`cat $tmpF | sed "s/^ //gm" | sed "s/ $//gm" | grep -v '^$' | wc -l`


### PR DESCRIPTION
lowercase hostnames are enforced by K8s ingress, so we need to make sure to follow this rule: https://www.linkedin.com/pulse/rfc-exception-jan-tomášek-dwfvf/

closes #101 